### PR TITLE
Push new versions to AUR

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -12,5 +12,8 @@ trim_trailing_whitespace = true
 [*.md]
 trim_trailing_whitespace = false
 
+[*.{yml,yaml}]
+indent_size = 2
+
 [Makefile]
 indent_style = tab

--- a/.github/assets/release/aur/.ssh/config
+++ b/.github/assets/release/aur/.ssh/config
@@ -1,0 +1,4 @@
+Host aur.archlinux.org
+    IdentitiesOnly=yes
+    IdentityFile ~/.ssh/aur
+    User aur

--- a/.github/assets/release/aur/PKGBUILD.template.sh
+++ b/.github/assets/release/aur/PKGBUILD.template.sh
@@ -1,0 +1,40 @@
+# Maintainer: Jérôme Deuchnord <jerome@deuchnord.fr>
+
+pkgname=kosmorro
+pkgver=___VERSION___
+pkgrel=1
+pkgdesc='A program that computes the ephemerides'
+
+depends=('python>=3.5.0' 'python<4.0.0'
+         'python-skyfield>=1.17' 'python-skyfield<2.0.0'
+         'python-numpy>=1.17.0' 'python-numpy<2.0.0'
+         'python-tabulate')
+optdepends=('texlive-bin: PDF creation support'
+            'python-latex: PDF creation support')
+makedepends=('python-setuptools'
+             'ruby-ronn')
+
+arch=('any')
+url='http://kosmorro.space'
+license=('AGPL3')
+
+source=("https://github.com/Deuchnord/kosmorro/archive/v${pkgver}.tar.gz"
+        "locales.tar.xz")
+sha256sums=("___HASH_PROGRAM___"
+            "___HASH_LOCALES___")
+
+build() {
+    pip install --user --isolated Babel
+    cp -r ${srcdir}/locales/* ${srcdir}/kosmorro-${pkgver}/kosmorrolib/locales
+
+    cd "${srcdir}/kosmorro-${pkgver}"
+    python setup.py build
+
+    cd "${srcdir}/kosmorro-${pkgver}"
+    python setup.py compile_catalog build
+}
+
+package() {
+    cd "${srcdir}/kosmorro-${pkgver}"
+    python3 setup.py install --root="${pkgdir}/" --optimize=1 --skip-build
+}

--- a/.github/assets/release/aur/SRCINFO.template
+++ b/.github/assets/release/aur/SRCINFO.template
@@ -1,0 +1,24 @@
+pkgbase = kosmorro
+	pkgdesc = A program that computes the ephemerides
+	pkgver = ___VERSION___
+	pkgrel = 1
+	url = http://kosmorro.space
+	arch = any
+	license = AGPL3
+	makedepends = python-setuptools
+	makedepends = ruby-ronn
+	depends = python>=3.5.0
+	depends = python<4.0.0
+	depends = python-skyfield>=1.17
+	depends = python-skyfield<2.0.0
+	depends = python-numpy>=1.17.0
+	depends = python-numpy<2.0.0
+	depends = python-tabulate
+	optdepends = texlive-bin: PDF creation support
+	optdepends = python-latex: PDF creation support
+	source = kosmorro-v___VERSION___.tar.gz::https://github.com/Deuchnord/kosmorro/archive/v___VERSION___.tar.gz
+	source = locales.tar.xz
+	sha256sums = ___HASH_PROGRAM___
+	sha256sums = ___HASH_LOCALES___
+
+pkgname = kosmorro

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,3 +34,51 @@ jobs:
         python .scripts/build/getlangs.py
         python setup.py compile_catalog sdist bdist_wheel
         twine upload dist/*
+
+  aur:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Setup AUR connection
+        env:
+          AUR_PRIVATE_KEY: ${{ secrets.AUR_PRIVATE_KEY }}
+        run: |
+          echo "$AUR_PRIVATE_KEY" > ~/.ssh/aur
+          cat .github/assets/release/aur/.ssh/config >> ~/.ssh/config
+          git config --global user.name "AUR Releaser on GitHub Action"
+          git config --global user.email "jerome@deuchnord.fr"
+
+      - name: Clone AUR package
+        run: |
+          git clone ssh://aur@aur.archlinux.org/kosmorro.git /tmp/aur-kosmorro
+
+      - name: Prepare locales archive
+        env:
+            POEDITOR_API_ACCESS: ${{ POEDITOR_API_ACCESS }}
+            POEDITOR_PROJECT_ID: 306433
+        run: |
+            POEDITOR_API_ACCESS=${POEDITOR_API_ACCESS} POEDITOR_PROJECT_ID=${POEDITOR_PROJECT_ID} python .scripts/build/getlangs.py
+            tar czf locales.tar.xz
+            cp locales.tar.xz /tmp/aur-kosmorro/locales.tar.xz
+
+      - name: Update version
+        run: |
+          hashProgram=$(curl https://codeload.github.com/Deuchnord/kosmorro/tar.gz/$GITHUB_REF | sha256sum)
+          hashLocales=$(sha256sum locales.tar.xz)
+
+          cp .github/assets/release/aur/PKGBUILD.template.sh /tmp/aur-kosmorro/PKGBUILD
+          cp .github/assets/release/aur/SRCINFO.template.sh /tmp/aur-kosmorro/.SRCINFO
+
+          sed "s/___VERSION___/$GITHUB_REF" /tmp/aur-kosmorro/PKGBUILD
+          sed "s/___HASH_PROGRAM___/$hashProgram" /tmp/aur-kosmorro/PKGBUILD
+          sed "s/___HASH_LOCALES___/$hashLocales" /tmp/aur-kosmorro/PKGBUILD
+
+          sed "s/___VERSION___/$GITHUB_REF" /tmp/aur-kosmorro/.SRCINFO
+          sed "s/___HASH_PROGRAM___/$hashProgram" /tmp/aur-kosmorro/.SRCINFO
+          sed "s/___HASH_LOCALES___/$hashLocales" /tmp/aur-kosmorro/.SRCINFO
+
+      - name: Push to AUR
+        run: |
+          cd /tmp/aur-kosmorro
+          git add PKGBUILD .SRCINFO locales.tar.xz
+          git commit -m "Release version $GITHUB_REF"
+          git push origin master


### PR DESCRIPTION
| Q              | A
| -------------- | ---
| Bug fix?       | no
| New feature?   | no
| Related issues | N/A
| Has BC-break   | no
| License        | GNU AGPL-v3

Push the new versions to AUR from CI.

TODO:

- [x] change `$tag` with the variable set by GitHub Action.
- [ ] add the [publish-aur-package](https://github.com/marketplace/actions/publish-aur-package) action
- [ ] update GitHub Action secrets
- [ ] update AUR configuration