### PR TITLE
fix: return next Moon phase with the correct time zone

### DIFF
--- a/_kosmorro/main.py
+++ b/_kosmorro/main.py
@@ -155,7 +155,7 @@ def get_information(
         eph = []
 
     try:
-        moon_phase = get_moon_phase(compute_date)
+        moon_phase = get_moon_phase(for_date=compute_date, timezone=timezone)
     except OutOfRangeDateError as error:
         moon_phase = None
         print(


### PR DESCRIPTION
| Q              | A
| -------------- | ---
| Bug fix?       | yes
| New feature?   | no
| Related issues | Fix #216 
| Has BC-break   | no
| License        | GNU AGPL-v3
