### PR TITLE
fix: fix localization for Earth and apsis

### DIFF
--- a/kosmorro/i18n/strings.py
+++ b/kosmorro/i18n/strings.py
@@ -54,6 +54,7 @@ def from_object(identifier: ObjectIdentifier) -> str:
         ObjectIdentifier.MOON: _("Moon"),
         ObjectIdentifier.MERCURY: _("Mercury"),
         ObjectIdentifier.VENUS: _("Venus"),
+        ObjectIdentifier.EARTH: _("Earth"),
         ObjectIdentifier.MARS: _("Mars"),
         ObjectIdentifier.JUPITER: _("Jupiter"),
         ObjectIdentifier.SATURN: _("Saturn"),

--- a/kosmorro/i18n/strings.py
+++ b/kosmorro/i18n/strings.py
@@ -15,8 +15,8 @@ def from_event(event: Event, with_description: bool = True) -> Union[None, str]:
             _("Elongation of %s is maximal"),
             lambda e: "{:.3n}°".format(e.details["deg"]),
         ),
-        EventType.PERIGEE: (_("%s is at its perigee"), None),
-        EventType.APOGEE: (_("%s is at its apogee"), None),
+        EventType.PERIGEE: (_("%s is at its periapsis"), None),
+        EventType.APOGEE: (_("%s is at its apoapsis"), None),
     }.get(event.event_type, (None, None))
 
     if string is None:

--- a/kosmorro/locales/messages.pot
+++ b/kosmorro/locales/messages.pot
@@ -8,14 +8,14 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2022-06-15 13:19+0200\n"
+"POT-Creation-Date: 2022-07-07 13:10+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Generated-By: Babel 2.10.2\n"
+"Generated-By: Babel 2.10.3\n"
 
 #: kosmorro/__main__.py:61
 msgid ""
@@ -233,12 +233,12 @@ msgstr ""
 
 #: kosmorro/i18n/strings.py:18
 #, python-format
-msgid "%s is at its perigee"
+msgid "%s is at its periapsis"
 msgstr ""
 
 #: kosmorro/i18n/strings.py:19
 #, python-format
-msgid "%s is at its apogee"
+msgid "%s is at its apoapsis"
 msgstr ""
 
 #: kosmorro/i18n/strings.py:35
@@ -290,26 +290,30 @@ msgid "Venus"
 msgstr ""
 
 #: kosmorro/i18n/strings.py:57
-msgid "Mars"
+msgid "Earth"
 msgstr ""
 
 #: kosmorro/i18n/strings.py:58
-msgid "Jupiter"
+msgid "Mars"
 msgstr ""
 
 #: kosmorro/i18n/strings.py:59
-msgid "Saturn"
+msgid "Jupiter"
 msgstr ""
 
 #: kosmorro/i18n/strings.py:60
-msgid "Uranus"
+msgid "Saturn"
 msgstr ""
 
 #: kosmorro/i18n/strings.py:61
-msgid "Neptune"
+msgid "Uranus"
 msgstr ""
 
 #: kosmorro/i18n/strings.py:62
+msgid "Neptune"
+msgstr ""
+
+#: kosmorro/i18n/strings.py:63
 msgid "Pluto"
 msgstr ""
 


### PR DESCRIPTION
| Q              | A
| -------------- | ---
| Bug fix?       | yes
| New feature?   | no
| Related issues | 
| Has BC-break   | no
| License        | GNU AGPL-v3

**Checklist:**
<!--
    Leave the checklist as it when editing, and check the boxes once the PR created.
-->
- [ ] I have updated the manpages

<!--
    Replace this notice with a short README for your feature/bugfix.
-->

- Current wording "apogee" and "perigee" is too specific to the Moon. It is not adapted to the Earth. Using the more generic _periapsis_ and _apoapsis_ instead (see [Apsis on Wikipedia](https://en.wikipedia.org/wiki/Apsis) for more details)
- Add missing string for the Earth (fixes the "None is at its apogee _(sic)_" issue)